### PR TITLE
Stops Plugin Intialization

### DIFF
--- a/source/platform.js
+++ b/source/platform.js
@@ -15,6 +15,11 @@ module.exports = function (uuidGen, accessory, ecobeeSensor) {
 
 
 function EcobeePlatform(log, config, homebridgeAPI) {
+ if (!config) {
+    log.warn(" Ignoring Ecobee3 Sensor Plugin setup because it is not configured");
+    this.disabled = true;
+    return;
+  }
   this.log = log;
   this.config = config || {};
 


### PR DESCRIPTION
This stops the plugin from unnecessarily initializing when the plugin isn't called in the config.json