### PR TITLE
Added support for current Ecobee models and an optional update frequency

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,7 +15,8 @@
       "exclude_humidity_sensors": false,
       "exclude_occupancy_sensors": false,
       "exclude_temperature_sensors": false,
-      "exclude_thermostat": false
+      "exclude_thermostat": false,
+      "update_frequency": 30
     }
   ]
 }

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
     "port": 51826,
     "pin": "031-45-154"
   },
-  "description": "Ecobee 3 Sensors plugin example configuration file.",
+  "description": "Ecobee Sensors plugin example configuration file.",
 
   "platforms": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-ecobee3-sensors",
-  "version": "0.1.5",
-  "description": "Homebridge plugin that exposes Ecobee 3 sensors as HomeKit accessories",
+  "version": "0.1.6",
+  "description": "Homebridge plugin that exposes Ecobee sensors as HomeKit accessories",
   "license": "MIT",
   "keywords": [
     "homebridge-plugin", "ecobee", "ecobee3", "smart thermostat", "sensor"

--- a/source/platform.js
+++ b/source/platform.js
@@ -228,7 +228,7 @@ EcobeePlatform.prototype.sensors = function (reply) {
   }
 
   for (var thermostatConfig of reply.thermostatList) {
-    if (thermostatConfig.modelNumber != 'athenaSmart') {
+    if ((thermostatConfig.modelNumber != 'athenaSmart') && (thermostatConfig.modelNumber != 'apolloSmart') && (thermostatConfig.modelNumber != 'nikeSmart')) {
       this.log.info("Not supported thermostat | " + thermostatConfig.name + " (" + thermostatConfig.modelNumber + ")");
       continue
     }

--- a/source/platform.js
+++ b/source/platform.js
@@ -16,7 +16,7 @@ module.exports = function (uuidGen, accessory, ecobeeSensor) {
 
 function EcobeePlatform(log, config, homebridgeAPI) {
  if (!config) {
-    log.warn(" Ignoring Ecobee3 Sensor Plugin setup because it is not configured");
+    log.warn(" Ignoring Ecobee Sensor Plugin setup because it is not configured");
     this.disabled = true;
     return;
   }
@@ -28,6 +28,7 @@ function EcobeePlatform(log, config, homebridgeAPI) {
   this.excludeOccupancySensors = this.config.exclude_occupancy_sensors || false;
   this.excludeTemperatureSensors = this.config.exclude_temperature_sensors || false;
   this.excludeThermostat = this.config.exclude_thermostat || false;
+  this.updateFrequency = this.config.update_frequency || 30;
 
   this.appKey = this.config.app_key || "DALCINnO49EYOmMfQQxmx7PYofM1YEGo";
   this.accessToken = null;
@@ -87,7 +88,7 @@ EcobeePlatform.prototype.pin = function () {
       this.log.debug(reply);
       var pin = reply['ecobeePin'];
       var code = reply['code'];
-      this.log.info("These are the steps authorize this application to access your Ecobee 3:");
+      this.log.info("These are the steps authorize this application to access your Ecobee:");
       this.log.info("  1. Go to https://www.ecobee.com/home/ecobeeLogin.jsp");
       this.log.info("  2. Login to your thermostat console ");
       this.log.info("  3. Select 'MY APPS' from the menu on the top right.");
@@ -194,8 +195,8 @@ EcobeePlatform.prototype.update = function (callback) {
         case 0:
           this.log.info("Update sensors");
           this.sensors(reply);
-          setTimeout(this.update.bind(this), 31*1000);
-          this.log.info("Wait | 30 seconds");
+          setTimeout(this.update.bind(this), this.updateFrequency*1000);
+          this.log.info("Wait | " + this.updateFrequency + " seconds");
           if (callback) callback();
           break;
         case 14:
@@ -223,7 +224,7 @@ EcobeePlatform.prototype.update = function (callback) {
 EcobeePlatform.prototype.sensors = function (reply) {
   this.log.debug("Setting values of sensors...");
   if (!reply.thermostatList || reply.thermostatList.length === 0) {
-    this.log.error("No Ecobee 3 thermostats found. Please, make soure your thermostat is registered.");
+    this.log.error("No Ecobee thermostats found. Please, make soure your thermostat is registered.");
     return;
   }
 


### PR DESCRIPTION
Added support for apolloSmart and nikeSmart models. Added a configurable update frequency that defaults to 30 seconds to be consistent with the original code. I am only tracking humidity (the only missing visible metric in Ecobee's HomeKit integration) and wanted to adjust the frequency to 120 seconds given how slowly the metric changes.