### PR TITLE
Added `vulcanSmart` as a supported modelNumber

### DIFF
--- a/source/platform.js
+++ b/source/platform.js
@@ -229,7 +229,7 @@ EcobeePlatform.prototype.sensors = function (reply) {
   }
 
   for (var thermostatConfig of reply.thermostatList) {
-    if ((thermostatConfig.modelNumber != 'athenaSmart') && (thermostatConfig.modelNumber != 'apolloSmart') && (thermostatConfig.modelNumber != 'nikeSmart')) {
+    if ((thermostatConfig.modelNumber != 'vulcanSmart') && (thermostatConfig.modelNumber != 'athenaSmart') && (thermostatConfig.modelNumber != 'apolloSmart') && (thermostatConfig.modelNumber != 'nikeSmart')) {
       this.log.info("Not supported thermostat | " + thermostatConfig.name + " (" + thermostatConfig.modelNumber + ")");
       continue
     }


### PR DESCRIPTION
Added `vulcanSmart` as a supported modelNumber. Simple change. Confirmed reads sensor data for the new model.