### PR TITLE
Fixed the problem with chalk@5.0.0 changed their API

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "homebridge": ">=0.4.6"
   },
   "dependencies": {
-    "chalk": ">=1.1.1"
+    "chalk": ">=1.1.1 <2.0.0"
   }
 }


### PR DESCRIPTION
Node.js v16.13.1
Homebridge v1.3.8

[12/20/2021, 3:24:09 PM] Loaded plugin: homebridge-ecobee3-sensors@0.1.7
Homebridge API version: 2.7
[12/20/2021, 3:24:09 PM] ====================
[12/20/2021, 3:24:09 PM] ERROR INITIALIZING PLUGIN homebridge-ecobee3-sensors:
[12/20/2021, 3:24:09 PM] Error [ERR_REQUIRE_ESM]: require() of ES Module /usr/lib/node_modules/homebridge-ecobee3-sensors/node_modules/chalk/source/index.js from /usr/lib/node_modules/homebridge-ecobee3-sensors/source/sensor.js not supported.
Instead change the require of index.js in /usr/lib/node_modules/homebridge-ecobee3-sensors/source/sensor.js to a dynamic import() which is available in all CommonJS modules.
at Object. (/usr/lib/node_modules/homebridge-ecobee3-sensors/source/sensor.js:4:13)
at Plugin.module.exports [as pluginInitializer] (/usr/lib/node_modules/homebridge-ecobee3-sensors/index.js:11:18)
at Plugin.initialize (/usr/lib/node_modules/homebridge/lib/plugin.js:147:21)
at PluginManager.initializePlugin (/usr/lib/node_modules/homebridge/lib/pluginManager.js:91:26)
at PluginManager.initializeInstalledPlugins (/usr/lib/node_modules/homebridge/lib/pluginManager.js:83:24)
at async Server.start (/usr/lib/node_modules/homebridge/lib/server.js:106:9)
[12/20/2021, 3:24:09 PM] ====================