### PR TITLE
Expose the HVAC Equipments (Fan, Heatpump, AirConditioner) as Contact Sensor

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,6 +16,7 @@
       "exclude_occupancy_sensors": false,
       "exclude_temperature_sensors": false,
       "exclude_thermostat": false,
+      "exclude_equipment_sensors": false,
       "update_frequency": 30,
       "log_level": 1
     }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ module.exports = function (homebridge) {
   UUIDGen = homebridge.hap.uuid;
 
   EcobeeSensor = require("./source/sensor.js")(Accessory, Service, Characteristic);
-  EcobeePlatform = require("./source/platform.js")(UUIDGen, Accessory, EcobeeSensor);
+  EcobeeEquipment = require("./source/equipment.js")(Accessory, Service, Characteristic);
+  EcobeePlatform = require("./source/platform.js")(UUIDGen, Accessory, EcobeeSensor, EcobeeEquipment);
 
   homebridge.registerPlatform("homebridge-ecobee3-sensors", "Ecobee 3 Sensors", EcobeePlatform, true);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,139 @@
+{
+  "name": "homebridge-ecobee3-sensors",
+  "version": "0.1.9",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "homebridge-ecobee3-sensors",
+      "version": "0.1.9",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": ">=1.1.1 <2.0.0"
+      },
+      "engines": {
+        "homebridge": ">=0.4.6",
+        "node": ">=4.3.2"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    }
+  },
+  "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "homebridge-ecobee3-sensors",
+  "name": "homebridge-ecobee3-sensors-equipments",
   "version": "0.1.9",
-  "description": "Homebridge plugin that exposes Ecobee sensors as HomeKit accessories",
+  "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [
     "homebridge-plugin", "ecobee", "ecobee3", "smart thermostat", "sensor"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "homebridge-ecobee3-sensors-equipments",
-  "version": "0.1.31",
-  "description": "Homebridge plugin that exposes Ecobee sensors/equipments as HomeKit accessories",
+  "name": "homebridge-ecobee3-sensors",
+  "version": "0.1.10",
+  "description": "Homebridge plugin that exposes Ecobee sensors as HomeKit accessories",
   "license": "MIT",
   "keywords": [
     "homebridge-plugin", "ecobee", "ecobee3", "smart thermostat", "sensor"

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,8 @@ Homebridge is setup via `config.json` file sitting in the `~/.homebridge/` direc
     "exclude_humidity_sensors": false,
     "exclude_occupancy_sensors": false,
     "exclude_temperature_sensors": false,
-    "exclude_thermostat": false
+    "exclude_thermostat": false,
+    "exclude_equipment_sensors": false
   }
 ]
 ```

--- a/source/equipment.js
+++ b/source/equipment.js
@@ -29,8 +29,8 @@ function EcobeeEquipment(log, config, platform, homebridgeAccessory) {
   informationService.getCharacteristic(Characteristic.SerialNumber).setValue('ecobee3-equipment-' + config.name);
 
   if (platform.excludeEquipmentSensors) return;
-  var switchService = this.homebridgeAccessory.getService(Service.ContactSensor);
-  switchService.displayName = config.name;
+  var switchService = this.homebridgeAccessory.addService(Service.ContactSensor);
+  switchService.displayName = 'Equipment';
   this.contactSensorCharacteristic = switchService.getCharacteristic(Characteristic.ContactSensorState);
 
   this.log.info(this.prefix, "Initialized | " + config.name);

--- a/source/equipment.js
+++ b/source/equipment.js
@@ -30,7 +30,8 @@ function EcobeeEquipment(log, config, platform, homebridgeAccessory) {
 
   if (platform.excludeEquipmentSensors) return;
   var switchService = this.homebridgeAccessory.getService(Service.ContactSensor);
-  this.temperatureCharacteristic = switchService.getCharacteristic(Characteristic.ContactSensorState);
+  switchService.displayName = config.name;
+  this.contactSensorCharacteristic = switchService.getCharacteristic(Characteristic.ContactSensorState);
 
   this.log.info(this.prefix, "Initialized | " + config.name);
   this.update(config);
@@ -41,12 +42,12 @@ EcobeeEquipment.prototype.update = function (status) {
   this.log.debug(this.prefix, "Updating equipment measurement...");
   this.log.debug(config);
 
-  if (this.temperatureCharacteristic) {
+  if (this.contactSensorCharacteristic) {
     var currentValue = status ?
       this.Characteristic.ContactSensorState.CONTACT_DETECTED :
       this.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED;
 
-    this.temperatureCharacteristic.setValue(currentValue);
+    this.contactSensorCharacteristic.setValue(currentValue);
     this.log.info(this.prefix, this.currentValue);
   }
 };

--- a/source/equipment.js
+++ b/source/equipment.js
@@ -31,12 +31,12 @@ function EcobeeEquipment(log, config, platform, homebridgeAccessory) {
 
   if (platform.excludeEquipmentSensors) return;
 
-  var service = this.homebridgeAccessory.getService(Service.StatefulProgrammableSwitch);
+  var service = this.homebridgeAccessory.getService(Service.ContactSensor);
   if (!service) {
-    service = this.homebridgeAccessory.addService(Service.StatefulProgrammableSwitch);
+    service = this.homebridgeAccessory.addService(Service.ContactSensor);
     service.displayName = 'Equipment';
   }
-  this.switchState = service.getCharacteristic(Characteristic.ProgrammableSwitchOutputState);
+  this.switchState = service.getCharacteristic(Characteristic.ContactSensorState);
 
   this.log.info(this.prefix, "Initialized | " + config.name);
   this.update(config);
@@ -47,7 +47,9 @@ EcobeeEquipment.prototype.update = function (status) {
   this.log.debug(this.prefix, "Updating equipment measurement " + this.name);
 
   if (this.switchState) {
-    var currentValue = status ? 1 : 0;
+    var currentValue = status ?
+      Characteristic.ContactSensorState.CONTACT_NOT_DETECTED :
+      Characteristic.ContactSensorState.CONTACT_DETECTED;
     this.switchState.setValue(currentValue);
     this.log.info(this.prefix, currentValue);
   }

--- a/source/equipment.js
+++ b/source/equipment.js
@@ -51,7 +51,7 @@ EcobeeEquipment.prototype.update = function (status) {
       Characteristic.ContactSensorState.CONTACT_NOT_DETECTED :
       Characteristic.ContactSensorState.CONTACT_DETECTED;
     this.switchState.setValue(currentValue);
-    this.log.info(this.prefix, currentValue);
+    this.log.info(this.prefix + " " + status);
   }
 };
 

--- a/source/equipment.js
+++ b/source/equipment.js
@@ -15,6 +15,7 @@ module.exports = function (accessory, service, characteristic) {
 function EcobeeEquipment(log, config, platform, homebridgeAccessory) {
   this.log = log;
   this.name = config.name;
+  this.isEquipment = true;
   this.prefix = Chalk.blue("[" + config.name + "]");
   this.log.debug(this.prefix, "Initializing equipment...");
   this.log.debug(config);

--- a/source/equipment.js
+++ b/source/equipment.js
@@ -26,13 +26,13 @@ function EcobeeEquipment(log, config, platform, homebridgeAccessory) {
   informationService.getCharacteristic(Characteristic.Name).setValue(config.name);
   informationService.getCharacteristic(Characteristic.Manufacturer).setValue("ecobee Inc.");
   informationService.getCharacteristic(Characteristic.Model).setValue("ecobee3 equipment");
-  informationService.getCharacteristic(Characteristic.SerialNumber).setValue(config.code);
+  informationService.getCharacteristic(Characteristic.SerialNumber).setValue('ecobee3-equipment-' + config.name);
 
   if (platform.excludeEquipmentSensors) return;
   var switchService = this.homebridgeAccessory.getService(Service.ContactSensor);
   this.temperatureCharacteristic = switchService.getCharacteristic(Characteristic.ContactSensorState);
 
-  this.log.info(this.prefix, "Initialized | " + config.code);
+  this.log.info(this.prefix, "Initialized | " + config.name);
   this.update(config);
 }
 

--- a/source/equipment.js
+++ b/source/equipment.js
@@ -31,7 +31,7 @@ function EcobeeEquipment(log, config, platform, homebridgeAccessory) {
 
   if (platform.excludeEquipmentSensors) return;
 
-  var switchService = this.homebridgeAccessory.getService(Service.TemperatureSensor);
+  var switchService = this.homebridgeAccessory.getService(Service.ContactSensor);
   if (!switchService) {
     switchService = this.homebridgeAccessory.addService(Service.ContactSensor);
     switchService.displayName = 'Equipment';

--- a/source/equipment.js
+++ b/source/equipment.js
@@ -1,0 +1,58 @@
+/* jshint esversion: 6 */
+
+var Accessory, Service, Characteristic;
+var Chalk = require('chalk');
+
+module.exports = function (accessory, service, characteristic) {
+  Accessory = accessory;
+  Service = service;
+  Characteristic = characteristic;
+
+  return EcobeeEquipment;
+};
+
+
+function EcobeeEquipment(log, config, platform, homebridgeAccessory) {
+  this.log = log;
+  this.name = config.name;
+  this.prefix = Chalk.blue("[" + config.name + "]");
+  this.log.debug(this.prefix, "Initializing equipment...");
+  this.log.debug(config);
+
+  this.homebridgeAccessory = homebridgeAccessory;
+  this.homebridgeAccessory.on('identify', this.identify.bind(this));
+
+  var informationService = this.homebridgeAccessory.getService(Service.AccessoryInformation);
+  informationService.getCharacteristic(Characteristic.Name).setValue(config.name);
+  informationService.getCharacteristic(Characteristic.Manufacturer).setValue("ecobee Inc.");
+  informationService.getCharacteristic(Characteristic.Model).setValue("ecobee3 equipment");
+  informationService.getCharacteristic(Characteristic.SerialNumber).setValue(config.code);
+
+  if (platform.excludeEquipmentSensors) return;
+  var switchService = this.homebridgeAccessory.getService(Service.ContactSensor);
+  this.temperatureCharacteristic = switchService.getCharacteristic(Characteristic.ContactSensorState);
+
+  this.log.info(this.prefix, "Initialized | " + config.code);
+  this.update(config);
+}
+
+
+EcobeeEquipment.prototype.update = function (status) {
+  this.log.debug(this.prefix, "Updating equipment measurement...");
+  this.log.debug(config);
+
+  if (this.temperatureCharacteristic) {
+    var currentValue = status ?
+      this.Characteristic.ContactSensorState.CONTACT_DETECTED :
+      this.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED;
+
+    this.temperatureCharacteristic.setValue(currentValue);
+    this.log.info(this.prefix, this.currentValue);
+  }
+};
+
+
+EcobeeEquipment.prototype.identify = function (callback) {
+  this.log.info(this.prefix, "Identify");
+  if (callback) callback();
+};

--- a/source/equipment.js
+++ b/source/equipment.js
@@ -43,8 +43,8 @@ EcobeeEquipment.prototype.update = function (status) {
 
   if (this.contactSensorCharacteristic) {
     var currentValue = status ?
-      this.Characteristic.ContactSensorState.CONTACT_DETECTED :
-      this.Characteristic.ContactSensorState.CONTACT_NOT_DETECTED;
+      Characteristic.ContactSensorState.CONTACT_DETECTED :
+      Characteristic.ContactSensorState.CONTACT_NOT_DETECTED;
 
     this.contactSensorCharacteristic.setValue(currentValue);
     this.log.info(this.prefix, this.currentValue);

--- a/source/equipment.js
+++ b/source/equipment.js
@@ -31,12 +31,12 @@ function EcobeeEquipment(log, config, platform, homebridgeAccessory) {
 
   if (platform.excludeEquipmentSensors) return;
 
-  var switchService = this.homebridgeAccessory.getService(Service.ContactSensor);
-  if (!switchService) {
-    switchService = this.homebridgeAccessory.addService(Service.ContactSensor);
-    switchService.displayName = 'Equipment';
+  var service = this.homebridgeAccessory.getService(Service.StatefulProgrammableSwitch);
+  if (!service) {
+    service = this.homebridgeAccessory.addService(Service.StatefulProgrammableSwitch);
+    service.displayName = 'Equipment';
   }
-  this.contactSensorCharacteristic = switchService.getCharacteristic(Characteristic.ContactSensorState);
+  this.switchState = service.getCharacteristic(Characteristic.ProgrammableSwitchOutputState);
 
   this.log.info(this.prefix, "Initialized | " + config.name);
   this.update(config);
@@ -46,13 +46,10 @@ function EcobeeEquipment(log, config, platform, homebridgeAccessory) {
 EcobeeEquipment.prototype.update = function (status) {
   this.log.debug(this.prefix, "Updating equipment measurement " + this.name);
 
-  if (this.contactSensorCharacteristic) {
-    var currentValue = status ?
-      Characteristic.ContactSensorState.CONTACT_DETECTED :
-      Characteristic.ContactSensorState.CONTACT_NOT_DETECTED;
-
-    this.contactSensorCharacteristic.setValue(currentValue);
-    this.log.info(this.prefix, this.currentValue);
+  if (this.switchState) {
+    var currentValue = status ? 1 : 0;
+    this.switchState.setValue(currentValue);
+    this.log.info(this.prefix, currentValue);
   }
 };
 

--- a/source/equipment.js
+++ b/source/equipment.js
@@ -39,8 +39,7 @@ function EcobeeEquipment(log, config, platform, homebridgeAccessory) {
 
 
 EcobeeEquipment.prototype.update = function (status) {
-  this.log.debug(this.prefix, "Updating equipment measurement...");
-  this.log.debug(config);
+  this.log.debug(this.prefix, "Updating equipment measurement " + this.name);
 
   if (this.contactSensorCharacteristic) {
     var currentValue = status ?

--- a/source/equipment.js
+++ b/source/equipment.js
@@ -30,8 +30,12 @@ function EcobeeEquipment(log, config, platform, homebridgeAccessory) {
   informationService.getCharacteristic(Characteristic.SerialNumber).setValue('ecobee3-equipment-' + config.name);
 
   if (platform.excludeEquipmentSensors) return;
-  var switchService = this.homebridgeAccessory.addService(Service.ContactSensor);
-  switchService.displayName = 'Equipment';
+
+  var switchService = this.homebridgeAccessory.getService(Service.TemperatureSensor);
+  if (!switchService) {
+    switchService = this.homebridgeAccessory.addService(Service.ContactSensor);
+    switchService.displayName = 'Equipment';
+  }
   this.contactSensorCharacteristic = switchService.getCharacteristic(Characteristic.ContactSensorState);
 
   this.log.info(this.prefix, "Initialized | " + config.name);

--- a/source/equipment.js
+++ b/source/equipment.js
@@ -39,7 +39,7 @@ function EcobeeEquipment(log, config, platform, homebridgeAccessory) {
   this.switchState = service.getCharacteristic(Characteristic.ContactSensorState);
 
   this.log.info(this.prefix, "Initialized | " + config.name);
-  this.update(config);
+  this.update(true);
 }
 
 
@@ -51,7 +51,7 @@ EcobeeEquipment.prototype.update = function (status) {
       Characteristic.ContactSensorState.CONTACT_NOT_DETECTED :
       Characteristic.ContactSensorState.CONTACT_DETECTED;
     this.switchState.setValue(currentValue);
-    this.log.info(this.prefix + " " + status);
+    this.log.info(this.prefix + " - " + status);
   }
 };
 

--- a/source/platform.js
+++ b/source/platform.js
@@ -370,7 +370,10 @@ EcobeePlatform.prototype.equipments = function (reply) {
     }
 
     for (var equipmentName in this.ecobeeAccessories) {
-      this.ecobeeAccessories[equipmentName].update(activeEquipments.includes(equipmentName));
+      var equipment = this.ecobeeAccessories[equipmentName];
+      if (equipment.isEquipment) {
+        equipment.update(activeEquipments.includes(equipmentName));
+      }
     }
   }
 

--- a/source/platform.js
+++ b/source/platform.js
@@ -374,9 +374,11 @@ EcobeePlatform.prototype.equipments = function (reply) {
   }
 
   for (var equipmentName in this.ecobeeAccessories) {
-    var equipment = this.ecobeeAccessories[equipmentName];
-    if (equipment.isEquipment && equipmentName.startsWith("Ecobee ")) {
-      equipment.update(activeEquipments.includes(equipmentName));
+    if (equipmentName.startsWith("Ecobee ")) {
+      var equipment = this.ecobeeAccessories[equipmentName];
+      if (equipment.isEquipment) {
+        equipment.update(activeEquipments.includes(equipmentName));
+      }
     }
   }
 };

--- a/source/platform.js
+++ b/source/platform.js
@@ -352,7 +352,7 @@ EcobeePlatform.prototype.equipments = function (reply) {
       for (var equipmentName of thermostatConfig.equipmentStatus.split(',')) {
         if (equipmentName === '') continue;
         equipmentName = "Ecobee " + equipmentName.trim();
-        var equipment = this.ecobeeAccessories[equipment];
+        var equipment = this.ecobeeAccessories[equipmentName];
       
         if (!equipment) {
           var homebridgeAccessory = this.homebridgeAccessories[equipmentName];

--- a/source/platform.js
+++ b/source/platform.js
@@ -342,13 +342,13 @@ EcobeePlatform.prototype.equipments = function (reply) {
     return;
   }
 
+  var activeEquipments = [];
   for (var thermostatConfig of reply.thermostatList) {
     if ((thermostatConfig.modelNumber != 'vulcanSmart') && (thermostatConfig.modelNumber != 'athenaSmart') && (thermostatConfig.modelNumber != 'apolloSmart') && (thermostatConfig.modelNumber != 'nikeSmart') && (thermostatConfig.modelNumber != 'aresSmart')) {
       this.log.info("Not supported thermostat | " + thermostatConfig.name + " (" + thermostatConfig.modelNumber + ")");
       continue
     }
 
-    var activeEquipments = [];
     if (thermostatConfig.equipmentStatus) {
       for (var equipmentName of thermostatConfig.equipmentStatus.split(',')) {
         if (equipmentName === '') continue;
@@ -368,12 +368,12 @@ EcobeePlatform.prototype.equipments = function (reply) {
         activeEquipments.push(equipmentName);
       }
     }
+  }
 
-    for (var equipmentName in this.ecobeeAccessories) {
-      var equipment = this.ecobeeAccessories[equipmentName];
-      if (equipment.isEquipment) {
-        equipment.update(activeEquipments.includes(equipmentName));
-      }
+  for (var equipmentName in this.ecobeeAccessories) {
+    var equipment = this.ecobeeAccessories[equipmentName];
+    if (equipment.isEquipment) {
+      equipment.update(activeEquipments.includes(equipmentName));
     }
   }
 

--- a/source/platform.js
+++ b/source/platform.js
@@ -359,7 +359,7 @@ EcobeePlatform.prototype.equipments = function (reply) {
           homebridgeAccessory.context['code'] = equipmentName;
           this.homebridgeAPI.registerPlatformAccessories("homebridge-ecobee3-equipments", "Ecobee Equipment", [homebridgeAccessory]);
         }
-        equipment = new EcobeeEquipment(this.log, sensorConfig, this, homebridgeAccessory);
+        equipment = new EcobeeEquipment(this.log, { name: equipmentName }, this, homebridgeAccessory);
         this.ecobeeAccessories[equipmentName] = equipment;
       }
       activeEquipments.push(equipmentName);

--- a/source/platform.js
+++ b/source/platform.js
@@ -375,7 +375,7 @@ EcobeePlatform.prototype.equipments = function (reply) {
 
   for (var equipmentName in this.ecobeeAccessories) {
     var equipment = this.ecobeeAccessories[equipmentName];
-    if (equipment.isEquipment) {
+    if (equipment.isEquipment && equipmentName.startsWith("Ecobee ")) {
       equipment.update(activeEquipments.includes(equipmentName));
     }
   }

--- a/source/platform.js
+++ b/source/platform.js
@@ -360,6 +360,9 @@ EcobeePlatform.prototype.equipments = function (reply) {
             homebridgeAccessory = new Accessory(equipmentName, UUIDGen.generate(`equipment ${equipmentName}`));
             homebridgeAccessory.context['code'] = equipmentName;
             this.homebridgeAPI.registerPlatformAccessories("homebridge-ecobee3-sensors", "Ecobee 3 Sensors", [homebridgeAccessory]);
+          } else {
+            this.log.info("Cached | " + equipmentName);
+            delete this.homebridgeAccessories[equipmentName];
           }
           equipment = new EcobeeEquipment(this.log, { name: equipmentName, code: equipmentName }, this, homebridgeAccessory);
           this.ecobeeAccessories[equipmentName] = equipment;

--- a/source/platform.js
+++ b/source/platform.js
@@ -307,7 +307,7 @@ EcobeePlatform.prototype.sensors = function (reply) {
       if (sensorConfig.type === 'ecobee3_remote_sensor') {
         if (this.excludeSensors) continue;
       }
-      if (config.capability) {
+      if (sensorConfig.capability) {
         var sensorCode = sensorConfig.code;
         var sensor = this.ecobeeAccessories[sensorCode];
 

--- a/source/platform.js
+++ b/source/platform.js
@@ -260,6 +260,7 @@ EcobeePlatform.prototype.update = function (callback) {
           this.sensors(reply);
           this.log.info("Update equipments");
           this.equipments(reply);
+          this.clean();
           setTimeout(this.update.bind(this), this.updateFrequency*1000);
           this.log.info("Wait | " + this.updateFrequency + " seconds");
           if (callback) callback();
@@ -330,8 +331,6 @@ EcobeePlatform.prototype.sensors = function (reply) {
       }
     }
   }
-
-  this.clean();
 };
 
 
@@ -362,7 +361,7 @@ EcobeePlatform.prototype.equipments = function (reply) {
             homebridgeAccessory.context['code'] = equipmentName;
             this.homebridgeAPI.registerPlatformAccessories("homebridge-ecobee3-sensors", "Ecobee 3 Sensors", [homebridgeAccessory]);
           }
-          equipment = new EcobeeEquipment(this.log, { name: equipmentName }, this, homebridgeAccessory);
+          equipment = new EcobeeEquipment(this.log, { name: equipmentName, code: equipmentName }, this, homebridgeAccessory);
           this.ecobeeAccessories[equipmentName] = equipment;
         }
         activeEquipments.push(equipmentName);
@@ -376,8 +375,6 @@ EcobeePlatform.prototype.equipments = function (reply) {
       equipment.update(activeEquipments.includes(equipmentName));
     }
   }
-
-  this.clean();
 };
 
 EcobeePlatform.prototype.clean = function () {

--- a/source/platform.js
+++ b/source/platform.js
@@ -348,23 +348,26 @@ EcobeePlatform.prototype.equipments = function (reply) {
     }
 
     var activeEquipments = [];
-    for (var equipmentName of thermostatConfig.equipmentStatus.split(',')) {
-      var equipment = this.ecobeeAccessories[equipment];
-    
-      if (!equipment) {
-        var homebridgeAccessory = this.homebridgeEquipmentAccessories[equipmentName];
-        if (!homebridgeAccessory) {
-          this.log.info("Create | " + equipmentName);
-          homebridgeAccessory = new Accessory(equipmentName, UUIDGen.generate(`equipment ${equipmentName}`));
-          homebridgeAccessory.context['code'] = equipmentName;
-          this.homebridgeAPI.registerPlatformAccessories("homebridge-ecobee3-equipments", "Ecobee Equipment", [homebridgeAccessory]);
+    if (thermostatConfig.equipmentStatus) {
+      for (var equipmentName of thermostatConfig.equipmentStatus.split(',')) {
+        if (equipmentName === '') continue;
+        var equipment = this.ecobeeAccessories[equipment];
+      
+        if (!equipment) {
+          var homebridgeAccessory = this.homebridgeEquipmentAccessories[equipmentName];
+          if (!homebridgeAccessory) {
+            this.log.info("Create | " + equipmentName);
+            homebridgeAccessory = new Accessory(equipmentName, UUIDGen.generate(`equipment ${equipmentName}`));
+            homebridgeAccessory.context['code'] = equipmentName;
+            this.homebridgeAPI.registerPlatformAccessories("homebridge-ecobee3-equipments", "Ecobee Equipment", [homebridgeAccessory]);
+          }
+          equipment = new EcobeeEquipment(this.log, { name: equipmentName }, this, homebridgeAccessory);
+          this.ecobeeAccessories[equipmentName] = equipment;
         }
-        equipment = new EcobeeEquipment(this.log, { name: equipmentName }, this, homebridgeAccessory);
-        this.ecobeeAccessories[equipmentName] = equipment;
+        activeEquipments.push(equipmentName);
       }
-      activeEquipments.push(equipmentName);
     }
-
+    
     for (var equipmentName in this.ecobeeAccessories) {
       this.ecobeeAccessories[equipmentName].update(activeEquipments.includes(equipmentName));
     }

--- a/source/platform.js
+++ b/source/platform.js
@@ -386,7 +386,11 @@ EcobeePlatform.prototype.clean = function () {
   for (var sensorCode in this.homebridgeAccessories) {
     var homebridgeAccessory = this.homebridgeAccessories[sensorCode];
     this.log.info("Remove | " + homebridgeAccessory.displayName + " - " + sensorCode);
+    try {
     this.homebridgeAPI.unregisterPlatformAccessories("homebridge-ecobee3-sensors", "Ecobee 3 Sensors", [homebridgeAccessory]);
+    } catch (e) {
+      this.log.error(e);
+    }
   }
 };
 

--- a/source/platform.js
+++ b/source/platform.js
@@ -351,6 +351,7 @@ EcobeePlatform.prototype.equipments = function (reply) {
     if (thermostatConfig.equipmentStatus) {
       for (var equipmentName of thermostatConfig.equipmentStatus.split(',')) {
         if (equipmentName === '') continue;
+        equipmentName = "Ecobee " + equipmentName.trim();
         var equipment = this.ecobeeAccessories[equipment];
       
         if (!equipment) {


### PR DESCRIPTION
Created Contact Sensor that indicates if any of the equipment like Fan, Heatpump, AirConditioner, etc are running.
This can be used for many scenarios:
For example, I am using it to turn on the Aroma Diffuser attach to my HVAC on, when the Fan is on.
Also, this can be used for alerting that for example windows or doors are open for very long time when HVAC is on.
