### PR TITLE
Clean up artemisSmart thermostat (remove dependency on .contains)

### DIFF
--- a/source/platform.js
+++ b/source/platform.js
@@ -5,6 +5,15 @@ var UUIDGen, Accessory, EcobeeSensor, EcobeeEquipment;
 var Querystring = require('querystring');
 var Https = require('https');
 
+const supportedThermostats = [
+    'artemisSmart',
+    'vulcanSmart',
+    'athenaSmart',
+    'apolloSmart',
+    'nikeSmart',
+    'aresSmart',
+];
+
 const Verbosity = Object.freeze({
     None: 0,
     Error: 1,
@@ -295,7 +304,7 @@ EcobeePlatform.prototype.sensors = function (reply) {
   }
 
   for (var thermostatConfig of reply.thermostatList) {
-    if ((thermostatConfig.modelNumber != 'vulcanSmart') && (thermostatConfig.modelNumber != 'athenaSmart') && (thermostatConfig.modelNumber != 'apolloSmart') && (thermostatConfig.modelNumber != 'nikeSmart') && (thermostatConfig.modelNumber != 'aresSmart')) {
+    if (!supportedThermostats.contains(thermostatConfig.modelNumber)) {
       this.log.info("Not supported thermostat | " + thermostatConfig.name + " (" + thermostatConfig.modelNumber + ")");
       continue
     }
@@ -343,7 +352,7 @@ EcobeePlatform.prototype.equipments = function (reply) {
 
   var activeEquipments = [];
   for (var thermostatConfig of reply.thermostatList) {
-    if ((thermostatConfig.modelNumber != 'vulcanSmart') && (thermostatConfig.modelNumber != 'athenaSmart') && (thermostatConfig.modelNumber != 'apolloSmart') && (thermostatConfig.modelNumber != 'nikeSmart') && (thermostatConfig.modelNumber != 'aresSmart')) {
+    if (!supportedThermostats.contains(thermostatConfig.modelNumber)) {
       this.log.info("Not supported thermostat | " + thermostatConfig.name + " (" + thermostatConfig.modelNumber + ")");
       continue
     }

--- a/source/platform.js
+++ b/source/platform.js
@@ -304,7 +304,7 @@ EcobeePlatform.prototype.sensors = function (reply) {
   }
 
   for (var thermostatConfig of reply.thermostatList) {
-    if (!supportedThermostats.contains(thermostatConfig.modelNumber)) {
+    if (supportedThermostats.indexOf(thermostatConfig.modelNumber) == -1) {
       this.log.info("Not supported thermostat | " + thermostatConfig.name + " (" + thermostatConfig.modelNumber + ")");
       continue
     }
@@ -352,7 +352,7 @@ EcobeePlatform.prototype.equipments = function (reply) {
 
   var activeEquipments = [];
   for (var thermostatConfig of reply.thermostatList) {
-    if (!supportedThermostats.contains(thermostatConfig.modelNumber)) {
+    if (supportedThermostats.indexOf(thermostatConfig.modelNumber) == -1) {
       this.log.info("Not supported thermostat | " + thermostatConfig.name + " (" + thermostatConfig.modelNumber + ")");
       continue
     }


### PR DESCRIPTION
Hello again, my node version on my Homebridge was apparently incompatible with my previous PR (but did work on my dev env). I tried updating node through `sudo hb-service update-node`, but I was still receiving `supportedThermostats.contains is not a function`. So this PR removes that dependency on .contains.

Including a screenshot of it working in HB.

![Screenshot 2025-01-27 at 10 19 23 AM](https://github.com/user-attachments/assets/a072fdaa-110a-4456-9794-c0bad5569364)
And I might as well include one from an automation in Home.app
![Screenshot 2025-01-27 at 10 21 06 AM](https://github.com/user-attachments/assets/3f257b40-5e21-4c9e-8a72-46440a9561ae)

Sorry for the double PR :)
